### PR TITLE
DEV-993 Update auth URL parameters

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "0.0.0.9",
+  "version": "0.0.0.10",
   "name": "Collab: Video calls in Notion— Daily API demo",
   "description": "Use the Daily API to embed and transcribe video calls directly in your Notion workspace.",
   "background": { "service_worker": "background.bundle.js" },

--- a/src/pages/constants.js
+++ b/src/pages/constants.js
@@ -1,2 +1,2 @@
 export const BASE_URL = 'https://daily-notion-api.vercel.app/api';
-export const REDIRECT_URL = `https://api.notion.com/v1/oauth/authorize?client_id=731d22e1-f838-4546-b78c-a8ec743310a0&redirect_uri=${BASE_URL}/workspaces&response_type=code`;
+export const REDIRECT_URL = `https://api.notion.com/v1/oauth/authorize?owner=user&client_id=731d22e1-f838-4546-b78c-a8ec743310a0&redirect_uri=${BASE_URL}/workspaces&response_type=code`;


### PR DESCRIPTION
Authentication has moved from the owner level to user level in Notion's API as of today. Our setup here still assumes it's at the owner level, so essentially one user token is getting shared until we update the backend functionality. Works the same either way but it's obviously not how we would set it up if starting today.

https://developers.notion.com/docs/authorization#prompting-users-to-add-an-integration

Eventually, I'll make the required changes in the UI/backend to reflect it being at the user level, but for now let's just update the required parameters.